### PR TITLE
Add documentation of so far un-documented get-ontology method in the API

### DIFF
--- a/skins/api.html
+++ b/skins/api.html
@@ -73,6 +73,13 @@ Data can be requested in JSON.<br> API calls follow the <a href="http://en.wikip
     <li><strong>Returns:</strong> JSON Hierarchy of the Ontologies under each category</li>
     <li><strong>Example:</strong> <span class="example"></span></li>
 </ul>
+<h2>Retrieve a specific Ontology</h2>
+<ul>
+    <li><strong>URL:</strong> <code>{{URL}}/get-ontology/{ontologyId}</code></li>
+    <li><strong>Method:</strong> <code>GET</code></li>
+    <li><strong>Returns:</strong> JSON representation of the ontology</li>
+    <li><strong>Example:</strong> <span class="example" ontologyId="CO_334"></span></li>
+</ul>
 <h2>Retrieve Ontology ID by its Name</h2>
 <ul>
     <li><strong>URL:</strong> <code>{{URL}}/get-ontology-id?ontology_name={ontology_name}</code></li>


### PR DESCRIPTION
I've made this change and I'm submitted the pull-request but there is something wrong and the example I give actually returns a null pointer exception. So before we merge this we'll want to fix this exception.
